### PR TITLE
fix circle buffer not full filled bug

### DIFF
--- a/js/circle.player.js
+++ b/js/circle.player.js
@@ -196,8 +196,10 @@ CirclePlayer.prototype = {
 		}
 	},
 	_progress: function(percent) {
-		var degs = percent * 3.6+"deg";
+		var degs;
 
+		percent = percent > 100 ? 100 : percent;
+		degs = percent * 3.6 + "deg";
 		if (this.cssTransforms) {
 			if (percent <= 50) {
 				this.jq.bufferHolder.removeClass(this.cssClass.gt50);


### PR DESCRIPTION
The circle buffer may not be full filled when it buffered to 100%, since `percent` in `_progress` is larger than 100 sometimes.
